### PR TITLE
Refactor: allow a watcher to watch multiple prefixes at once

### DIFF
--- a/crates/reaperd/src/node_reaper.rs
+++ b/crates/reaperd/src/node_reaper.rs
@@ -31,7 +31,7 @@ pub async fn initialise(
     watcher::setup_watcher(
         &etcd_config,
         state.clone(),
-        prefix::node_heartbeat_alive(&etcd_config, NodeType::Worker),
+        vec![prefix::node_heartbeat_alive(&etcd_config, NodeType::Worker)],
     )
     .await?;
 

--- a/crates/reaperd/src/pod_reaper.rs
+++ b/crates/reaperd/src/pod_reaper.rs
@@ -34,7 +34,7 @@ pub async fn initialise(
     watcher::setup_watcher(
         &etcd_config,
         state.clone(),
-        prefix::claimed_pods(&etcd_config),
+        vec![prefix::claimed_pods(&etcd_config)],
     )
     .await?;
 

--- a/crates/schedulerd/src/node_watcher.rs
+++ b/crates/schedulerd/src/node_watcher.rs
@@ -28,16 +28,17 @@ pub async fn initialise(etcd_config: etcd::Config) -> Result<State, Error> {
         node_available_memory: HashMap::new(),
     }));
 
-    let prefixes = &[
-        prefix::node_heartbeat_healthy(&etcd_config, NodeType::Worker),
-        prefix::node_available_cpu(&etcd_config, NodeType::Worker),
-        prefix::node_available_memory(&etcd_config, NodeType::Worker),
-        prefix::resource(&etcd_config, &NodeType::Worker.to_string()),
-    ];
-
-    for prefix in prefixes {
-        watcher::setup_watcher(&etcd_config, inner.clone(), prefix.clone()).await?;
-    }
+    watcher::setup_watcher(
+        &etcd_config,
+        inner.clone(),
+        vec![
+            prefix::node_heartbeat_healthy(&etcd_config, NodeType::Worker),
+            prefix::node_available_cpu(&etcd_config, NodeType::Worker),
+            prefix::node_available_memory(&etcd_config, NodeType::Worker),
+            prefix::resource(&etcd_config, &NodeType::Worker.to_string()),
+        ],
+    )
+    .await?;
 
     Ok(State(inner))
 }

--- a/crates/schedulerd/src/pod_scheduler.rs
+++ b/crates/schedulerd/src/pod_scheduler.rs
@@ -52,7 +52,7 @@ pub async fn initialise(
     watcher::setup_watcher(
         &etcd_config,
         state.clone(),
-        prefix::unscheduled_pods(&etcd_config),
+        vec![prefix::unscheduled_pods(&etcd_config)],
     )
     .await?;
 

--- a/crates/workerd/src/cluster_nameserver.rs
+++ b/crates/workerd/src/cluster_nameserver.rs
@@ -65,7 +65,7 @@ pub async fn initialise(
     watcher::setup_watcher(
         &etcd_config,
         state.clone(),
-        prefix::domain_name(&etcd_config),
+        vec![prefix::domain_name(&etcd_config)],
     )
     .await?;
 

--- a/crates/workerd/src/pod_claimer.rs
+++ b/crates/workerd/src/pod_claimer.rs
@@ -48,7 +48,7 @@ pub async fn initialise(
     watcher::setup_watcher(
         &etcd_config,
         state.clone(),
-        prefix::worker_inbox(&etcd_config, &my_name),
+        vec![prefix::worker_inbox(&etcd_config, &my_name)],
     )
     .await?;
 

--- a/crates/workerd/src/pod_killer.rs
+++ b/crates/workerd/src/pod_killer.rs
@@ -26,7 +26,7 @@ pub async fn initialise(
     watcher::setup_watcher(
         &etcd_config,
         state.clone(),
-        prefix::claimed_pods(&etcd_config),
+        vec![prefix::claimed_pods(&etcd_config)],
     )
     .await?;
 


### PR DESCRIPTION
This reduces load on etcd by using a single connection for all the watchers.  Since I'm already disambiguating based on prefix, this is an easy change.

Next step will be to refactor the daemons to merge all their watchers.