### PR TITLE
Refactor: replace bounded mpsc channels with unbounded

### DIFF
--- a/crates/nodelib/src/error.rs
+++ b/crates/nodelib/src/error.rs
@@ -74,7 +74,6 @@ impl From<serde_json::Error> for ResourceError {
 /// Errors specific to streaming RPCs.
 #[derive(Debug)]
 pub enum StreamingError {
-    CannotSend,
     Ended,
     TimedOut,
 }

--- a/crates/workerd/src/pod_claimer.rs
+++ b/crates/workerd/src/pod_claimer.rs
@@ -3,7 +3,6 @@ use std::process;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
-use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::sync::RwLock;
 use tonic::Request;
 
@@ -32,16 +31,15 @@ pub async fn initialise(
     etcd_config: etcd::Config,
     my_name: String,
     lease_id: LeaseId,
-    work_pod_tx: Sender<PodResource>,
+    work_pod_tx: mpsc::UnboundedSender<PodResource>,
 ) -> Result<Handle, Error> {
-    let (new_pod_tx, new_pod_rx) = mpsc::channel(128);
+    let (new_pod_tx, new_pod_rx) = mpsc::unbounded_channel();
 
     let state = Arc::new(RwLock::new(WatchState {
         running: true,
         etcd_config: etcd_config.clone(),
         my_name: my_name.clone(),
         unclaimed_pods: HashMap::new(),
-        unworked_pods: HashMap::new(),
         new_pod_tx,
     }));
 
@@ -52,14 +50,8 @@ pub async fn initialise(
     )
     .await?;
 
-    tokio::spawn(claim_task(
-        state.clone(),
-        lease_id,
-        new_pod_rx,
-        work_pod_tx.clone(),
-    ));
-    tokio::spawn(retry_claim_task(state.clone()));
-    tokio::spawn(retry_work_task(state.clone(), work_pod_tx));
+    tokio::spawn(claim_task(state.clone(), lease_id, new_pod_rx, work_pod_tx));
+    tokio::spawn(retry_task(state.clone()));
 
     Ok(Handle { ws: state.clone() })
 }
@@ -80,12 +72,11 @@ impl Handle {
 /// State to schedule pods.
 #[derive(Debug)]
 struct WatchState {
-    pub running: bool,
-    pub my_name: String,
-    pub etcd_config: etcd::Config,
-    pub unclaimed_pods: HashMap<String, PodResource>,
-    pub unworked_pods: HashMap<String, PodResource>,
-    pub new_pod_tx: Sender<String>,
+    running: bool,
+    my_name: String,
+    etcd_config: etcd::Config,
+    unclaimed_pods: HashMap<String, PodResource>,
+    new_pod_tx: mpsc::UnboundedSender<String>,
 }
 
 impl watcher::Watcher for WatchState {
@@ -100,9 +91,9 @@ impl watcher::Watcher for WatchState {
                 if let Ok(resource) = PodResource::try_from(kv.value) {
                     tracing::info!(name, "found new pod");
                     self.unclaimed_pods.insert(name.to_owned(), resource);
-                    if let Err(error) = self.new_pod_tx.try_send(name.to_owned()) {
-                        tracing::warn!(name, ?error, "could not trigger claimer");
-                    }
+                    self.new_pod_tx
+                        .send(name.to_owned())
+                        .expect("could not send to unbounded channel");
                 } else {
                     tracing::warn!(?key, "could not parse pod definition");
                 }
@@ -117,47 +108,16 @@ impl watcher::Watcher for WatchState {
 
 /// Background task to queue up all unclaimed pods every `RETRY_INTERVAL`
 /// seconds.
-async fn retry_claim_task(state: Arc<RwLock<WatchState>>) {
+async fn retry_task(state: Arc<RwLock<WatchState>>) {
     loop {
         tokio::time::sleep(Duration::from_secs(RETRY_INTERVAL)).await;
 
-        let pods_to_retry = {
-            let r = state.read().await;
-            r.unclaimed_pods.keys().cloned().collect::<Vec<_>>()
-        };
-
-        if !pods_to_retry.is_empty() {
-            tracing::info!(count = ?pods_to_retry.len(), "retrying unclaimed pods");
-            let w = state.write().await;
-            for name in pods_to_retry {
-                tracing::info!(name, "retrying unclaimed pod");
-                if let Err(error) = w.new_pod_tx.try_send(name.clone()) {
-                    tracing::warn!(name, ?error, "could not trigger claimer");
-                }
-            }
-        }
-    }
-}
-
-/// Background task to queue up all unworked pods every `RETRY_INTERVAL`
-/// seconds.
-async fn retry_work_task(state: Arc<RwLock<WatchState>>, work_pod_tx: Sender<PodResource>) {
-    loop {
-        tokio::time::sleep(Duration::from_secs(RETRY_INTERVAL)).await;
-
-        let mut w = state.write().await;
-        if !w.unworked_pods.is_empty() {
-            let count = w.unworked_pods.len();
-            tracing::info!(?count, "retrying unworked pods");
-            let mut new_unworked_pods = HashMap::with_capacity(count);
-            for (name, pod) in w.unworked_pods.drain() {
-                tracing::info!(name, "retrying unworked pod");
-                if let Err(error) = work_pod_tx.try_send(pod.clone()) {
-                    tracing::warn!(name, ?error, "could not trigger worker");
-                    new_unworked_pods.insert(name, pod);
-                }
-            }
-            w.unworked_pods = new_unworked_pods;
+        let r = state.read().await;
+        for name in r.unclaimed_pods.keys() {
+            tracing::info!(name, "retrying unclaimed pod");
+            r.new_pod_tx
+                .send(name.clone())
+                .expect("could not send to unbounded channel");
         }
     }
 }
@@ -166,23 +126,23 @@ async fn retry_work_task(state: Arc<RwLock<WatchState>>, work_pod_tx: Sender<Pod
 async fn claim_task(
     state: Arc<RwLock<WatchState>>,
     lease_id: LeaseId,
-    mut new_pod_rx: Receiver<String>,
-    work_pod_tx: Sender<PodResource>,
+    mut new_pod_rx: mpsc::UnboundedReceiver<String>,
+    work_pod_tx: mpsc::UnboundedSender<PodResource>,
 ) {
     while let Some(pod_name) = new_pod_rx.recv().await {
         let mut w = state.write().await;
         if !w.running {
             tracing::info!(pod_name, "got claim request but worker is terminating");
-            return;
+            continue;
         }
+
         if let Some(resource) = w.unclaimed_pods.remove(&pod_name) {
             tracing::info!(pod_name, "got claim request");
             match claim_pod(&w, lease_id, resource.clone()).await {
                 Ok(Some(resource)) => {
-                    if let Err(error) = work_pod_tx.try_send(resource.clone()) {
-                        tracing::warn!(pod_name, ?error, "could not work pod, retrying...");
-                        w.unworked_pods.insert(pod_name.to_owned(), resource);
-                    }
+                    work_pod_tx
+                        .send(resource.clone())
+                        .expect("could not send to unbounded channel");
                 }
                 Ok(None) => {
                     tracing::info!(pod_name, "pod killed before claim");

--- a/crates/workerd/src/pod_killer.rs
+++ b/crates/workerd/src/pod_killer.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 
@@ -10,17 +9,13 @@ use nodelib::etcd::prefix;
 use nodelib::etcd::watcher;
 use nodelib::resources::pod::PodType;
 
-/// Interval to retry pods that could not be killed.
-pub static RETRY_INTERVAL: u64 = 5;
-
 /// Set up a watcher and background tasks to kill our pods if the claims are deleted.
 pub async fn initialise(
     etcd_config: etcd::Config,
-    kill_pod_tx: mpsc::Sender<String>,
+    kill_pod_tx: mpsc::UnboundedSender<String>,
 ) -> Result<(), Error> {
     let state = Arc::new(RwLock::new(WatchState {
         etcd_config: etcd_config.clone(),
-        unkilled_pods: Vec::new(),
         kill_pod_tx,
     }));
 
@@ -31,17 +26,14 @@ pub async fn initialise(
     )
     .await?;
 
-    tokio::spawn(retry_task(state.clone()));
-
     Ok(())
 }
 
 /// State to schedule pods.
 #[derive(Debug)]
 struct WatchState {
-    pub etcd_config: etcd::Config,
-    pub unkilled_pods: Vec<String>,
-    pub kill_pod_tx: mpsc::Sender<String>,
+    etcd_config: etcd::Config,
+    kill_pod_tx: mpsc::UnboundedSender<String>,
 }
 
 impl watcher::Watcher for WatchState {
@@ -53,40 +45,12 @@ impl watcher::Watcher for WatchState {
 
         if let Some((_, name)) = key.split_once(&pod_resource_prefix) {
             if is_delete {
-                if let Err(error) = self.kill_pod_tx.try_send(name.to_owned()) {
-                    tracing::warn!(name, ?error, "could not trigger killer");
-                    self.unkilled_pods.push(name.to_owned());
-                }
+                self.kill_pod_tx
+                    .send(name.to_owned())
+                    .expect("could not send to unbounded channel");
             }
         } else {
             tracing::warn!(?key, "unexpected watch key");
-        }
-    }
-}
-
-/// Background task to queue up all unkilled pods every `RETRY_INTERVAL`
-/// seconds.
-async fn retry_task(state: Arc<RwLock<WatchState>>) {
-    loop {
-        tokio::time::sleep(Duration::from_secs(RETRY_INTERVAL)).await;
-
-        let count = {
-            let r = state.read().await;
-            r.unkilled_pods.len()
-        };
-
-        if count > 0 {
-            tracing::info!(?count, "retrying unkilled pods");
-            let mut w = state.write().await;
-            let mut new = Vec::with_capacity(w.unkilled_pods.len());
-            for name in &w.unkilled_pods {
-                tracing::info!(name, "retrying unclaimed pod");
-                if let Err(error) = w.kill_pod_tx.try_send(name.to_owned()) {
-                    tracing::warn!(name, ?error, "could not trigger killer");
-                    new.push(name.to_owned());
-                }
-            }
-            w.unkilled_pods = new;
         }
     }
 }


### PR DESCRIPTION
This lets me rip out all the error handling relating to failures to send, as that should never happen (with a minor tweak to the pod claimer).