### PR TITLE
Allow passing --cluster-address and --external-address in files

### DIFF
--- a/crates/apid/src/main.rs
+++ b/crates/apid/src/main.rs
@@ -1,5 +1,7 @@
 use clap::Parser;
+use std::fs;
 use std::net::Ipv4Addr;
+use std::path::PathBuf;
 use std::process;
 
 use nodelib::etcd;
@@ -23,10 +25,28 @@ struct Args {
     #[clap(long = "cluster-address", value_parser, env = "CLUSTER_ADDRESS")]
     pub cluster_address: Option<Ipv4Addr>,
 
+    /// Read the cluster address from a file.  This option is incompatible with
+    /// `--cluster-address`.
+    #[clap(
+        long = "cluster-address-file",
+        value_parser,
+        env = "CLUSTER_ADDRESS_FILE"
+    )]
+    pub cluster_address_file: Option<PathBuf>,
+
     /// External address to bind on to provide services to out-of-cluster users.
     /// This, or `--cluster-address`, or both must be specified.
     #[clap(long = "external-address", value_parser, env = "EXTERNAL_ADDRESS")]
     pub external_address: Option<Ipv4Addr>,
+
+    /// Read the external address from a file.  This option is incompatible with
+    /// `--external-address`.
+    #[clap(
+        long = "external-address-file",
+        value_parser,
+        env = "EXTERNAL_ADDRESS_FILE"
+    )]
+    pub external_address_file: Option<PathBuf>,
 
     #[command(flatten)]
     pub etcd: etcd::Config,
@@ -39,19 +59,55 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let Args {
         name,
         cluster_address,
+        cluster_address_file,
         external_address,
+        external_address_file,
         etcd,
     } = Args::parse();
 
-    if cluster_address.is_none() && external_address.is_none() {
+    let actual_cluster_address = match (cluster_address, cluster_address_file) {
+        (Some(_), Some(_)) => {
+            tracing::error!(
+                "--cluster-address cannot be specified at the same time as --cluster-address-file"
+            );
+            process::exit(1);
+        }
+        (Some(ip), _) => Some(ip),
+        (_, Some(fpath)) => match read_ip_from_file(fpath) {
+            Ok(ip) => Some(ip),
+            Err(error) => {
+                tracing::error!(?error, "cannot parse --cluster-address-file");
+                process::exit(1);
+            }
+        },
+        (_, _) => None,
+    };
+
+    let actual_external_address = match (external_address, external_address_file) {
+        (Some(_), Some(_)) => {
+            tracing::error!("--external-address cannot be specified at the same time as --external-address-file");
+            process::exit(1);
+        }
+        (Some(ip), _) => Some(ip),
+        (_, Some(fpath)) => match read_ip_from_file(fpath) {
+            Ok(ip) => Some(ip),
+            Err(error) => {
+                tracing::error!(?error, "cannot parse --external-address-file");
+                process::exit(1);
+            }
+        },
+        (_, _) => None,
+    };
+
+    if actual_cluster_address.is_none() && actual_external_address.is_none() {
         tracing::error!("--cluster-address or --external-address (or both) must be given");
         process::exit(1);
     }
 
-    if let Some(address) = cluster_address {
+    if let Some(address) = actual_cluster_address {
         tokio::spawn(web::serve(etcd.clone(), address));
     }
-    if let Some(address) = external_address {
+    if let Some(address) = actual_external_address {
         tokio::spawn(web::serve(etcd.clone(), address));
     }
 
@@ -60,7 +116,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         name,
         NodeType::Api,
         NodeSpec {
-            address: cluster_address,
+            address: actual_cluster_address,
             limits: None,
         },
         Some(SPECIAL_HOSTNAME),
@@ -70,4 +126,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let ch = nodelib::wait_for_sigterm(state).await;
     nodelib::signal_channel(ch).await;
     process::exit(0)
+}
+
+fn read_ip_from_file(p: PathBuf) -> Result<Ipv4Addr, Box<dyn std::error::Error>> {
+    let ip = fs::read_to_string(p)?.parse()?;
+
+    Ok(ip)
 }


### PR DESCRIPTION
This is useful for dynamically generated config, such as reading the flannel gateway IP from a file generated after connecting to the network.