### PR TITLE
Alow setting `--name` via env vars

### DIFF
--- a/crates/apid/src/main.rs
+++ b/crates/apid/src/main.rs
@@ -17,7 +17,7 @@ pub static SPECIAL_HOSTNAME: &str = "api";
 struct Args {
     /// Name of this instance, must be unique across the cluster.  If
     /// unspecified, a random name is generated.
-    #[clap(long)]
+    #[clap(long, env = "NODE_NAME")]
     pub name: Option<String>,
 
     /// Cluster address to bind on to provide services to pods.  This, or

--- a/crates/reaperd/src/main.rs
+++ b/crates/reaperd/src/main.rs
@@ -14,7 +14,7 @@ use reaperd::watcher;
 struct Args {
     /// Name of this instance, must be unique across the cluster.  If
     /// unspecified, a random name is generated.
-    #[clap(long)]
+    #[clap(long, env = "NODE_NAME")]
     pub name: Option<String>,
 
     #[command(flatten)]

--- a/crates/schedulerd/src/main.rs
+++ b/crates/schedulerd/src/main.rs
@@ -14,7 +14,7 @@ use schedulerd::watcher;
 struct Args {
     /// Name of this instance, must be unique across the cluster.  If
     /// unspecified, a random name is generated.
-    #[clap(long)]
+    #[clap(long, env = "NODE_NAME")]
     pub name: Option<String>,
 
     #[command(flatten)]

--- a/crates/workerd/src/main.rs
+++ b/crates/workerd/src/main.rs
@@ -23,7 +23,7 @@ pub static SPECIAL_HOSTNAME: &str = "dns";
 struct Args {
     /// Name of this instance, must be unique across the cluster.  If
     /// unspecified, a random name is generated.
-    #[clap(long)]
+    #[clap(long, env = "NODE_NAME")]
     pub name: Option<String>,
 
     /// Address to bind on to provide services to local pods.  Must be reachable


### PR DESCRIPTION
This makes it consistent with the other flags.