### PR TITLE
Remove `nix flake check` from lint target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
-      - run: nix flake check
       - run: nix run .#fmt
       - run: nix run .#lint
 


### PR DESCRIPTION
This is now done in the integration tests target.