### PR TITLE
Add support for basic scheduling constraints 

### DIFF
--- a/crates/schedulerd/src/lib.rs
+++ b/crates/schedulerd/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::missing_errors_doc)]
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::must_use_candidate)]
 #![allow(clippy::wildcard_imports)]
 
 pub mod scheduler;

--- a/crates/schedulerd/src/scheduler.rs
+++ b/crates/schedulerd/src/scheduler.rs
@@ -166,8 +166,12 @@ fn choose_worker_for_pod(
     let limits = pod.spec.aggregate_resources();
     let mut candidates = Vec::with_capacity(workers.len());
     for (name, node) in workers {
-        if limits.cpu_ok(node.available_cpu) && limits.memory_ok(node.available_memory) {
-            candidates.push(name.to_owned());
+        let worker_name = name.to_owned();
+        if pod.spec.is_worker_acceptable(&worker_name)
+            && limits.cpu_ok(node.available_cpu)
+            && limits.memory_ok(node.available_memory)
+        {
+            candidates.push(worker_name);
         }
     }
     candidates.choose(&mut rand::thread_rng()).cloned()

--- a/crates/tools/src/bin/nginx_hello_world.rs
+++ b/crates/tools/src/bin/nginx_hello_world.rs
@@ -33,6 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     ports: vec![ContainerPortSpec::Expose(80)],
                     resources: None,
                 }],
+                scheduling_constraints: None,
             },
         )
         .with_state(PodState::Created),

--- a/crates/tools/src/bin/pod_spammer.rs
+++ b/crates/tools/src/bin/pod_spammer.rs
@@ -64,6 +64,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             limits: None,
                         }),
                     }],
+                    scheduling_constraints: None,
                 },
             )
             .with_state(PodState::Created),


### PR DESCRIPTION
This commit allows a pod to specify a list of workers that it *may* be
scheduled on, and a list of workers that it *cannot* be scheduled on.
The workers which meet the resource requirements are filtered by these
two lists.

This is a really basic building block of ReplicaSets: if the desired
number of pods doesn't match the expected number, it'll create more pods
with the constraint that they're not scheduled to any of the workers
currently running one of the ReplicaSets' pods.  A more robust approach
would be being able to say something like "don't schedule to a worker
that is running a pod with such-and-such metadata", but right now the
scheduler doesn't directly know anything about the pods a worker is
running, and I want to think a bit more about the best way to do that.