### PR TITLE
Implement API endpoints to manage DNS aliases (& refactoring)

### DIFF
--- a/crates/apid/src/web/dns_aliases.rs
+++ b/crates/apid/src/web/dns_aliases.rs
@@ -1,0 +1,155 @@
+use axum::extract::{Json, Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use std::str::FromStr;
+
+use nodelib::dns;
+use nodelib::etcd;
+use nodelib::util;
+
+use crate::web::errors::ProblemDetail;
+
+/// List all DNS aliases for the given "from" name.
+pub async fn list(
+    State(etcd_config): State<etcd::Config>,
+    Path((from_ns, from_hostname)): Path<(String, String)>,
+) -> impl IntoResponse {
+    match validate_name(&from_ns, &from_hostname) {
+        Ok(from_namespace) => {
+            match dns::list_aliases(&etcd_config, &from_namespace, &from_hostname).await {
+                Ok(aliases) => (StatusCode::OK, Json(aliases)).into_response(),
+                Err(error) => ProblemDetail::from_error(error).into_response(),
+            }
+        }
+        Err(error) => error.into_response(),
+    }
+}
+
+/// Check if a specific DNS alias exists - returns 201 No Content on success,
+/// since an alias has no data associated with it.
+pub async fn get(
+    State(etcd_config): State<etcd::Config>,
+    Path((from_ns, from_hostname, to_ns, to_hostname)): Path<(String, String, String, String)>,
+) -> impl IntoResponse {
+    match (
+        validate_name(&from_ns, &from_hostname),
+        validate_name(&to_ns, &to_hostname),
+    ) {
+        (Ok(from_namespace), Ok(to_namespace)) => match dns::alias_record_exists(
+            &etcd_config,
+            &from_namespace,
+            &from_hostname,
+            &to_namespace,
+            &to_hostname,
+        )
+        .await
+        {
+            Ok(true) => (StatusCode::NO_CONTENT, ()).into_response(),
+            Ok(false) => ProblemDetail::dns_alias_not_found(
+                &from_namespace,
+                &from_hostname,
+                &to_namespace,
+                &to_hostname,
+            )
+            .into_response(),
+            Err(error) => ProblemDetail::from_error(error).into_response(),
+        },
+        (Err(error), _) | (_, Err(error)) => error.into_response(),
+    }
+}
+
+/// Create a DNS alias - this is idempotent, so it doesn't check for
+/// nonexistence first.
+pub async fn put(
+    State(etcd_config): State<etcd::Config>,
+    Path((from_ns, from_hostname, to_ns, to_hostname)): Path<(String, String, String, String)>,
+) -> impl IntoResponse {
+    match validate_modify(&from_ns, &from_hostname, &to_ns, &to_hostname) {
+        Ok((from_namespace, to_namespace)) => match dns::append_alias_record(
+            &etcd_config,
+            None,
+            &from_namespace,
+            &from_hostname,
+            &to_namespace,
+            &to_hostname,
+        )
+        .await
+        {
+            Ok(()) => (StatusCode::NO_CONTENT, ()).into_response(),
+            Err(error) => ProblemDetail::from_error(error).into_response(),
+        },
+        Err(pb) => pb.into_response(),
+    }
+}
+
+/// Delete a specific DNS alias.
+pub async fn delete(
+    State(etcd_config): State<etcd::Config>,
+    Path((from_ns, from_hostname, to_ns, to_hostname)): Path<(String, String, String, String)>,
+) -> impl IntoResponse {
+    match validate_modify(&from_ns, &from_hostname, &to_ns, &to_hostname) {
+        Ok((from_namespace, to_namespace)) => match dns::delete_alias_record(
+            &etcd_config,
+            &from_namespace,
+            &from_hostname,
+            &to_namespace,
+            &to_hostname,
+        )
+        .await
+        {
+            Ok(true) => (StatusCode::NO_CONTENT, ()).into_response(),
+            Ok(false) => ProblemDetail::dns_alias_not_found(
+                &from_namespace,
+                &from_hostname,
+                &to_namespace,
+                &to_hostname,
+            )
+            .into_response(),
+            Err(error) => ProblemDetail::from_error(error).into_response(),
+        },
+        Err(pb) => pb.into_response(),
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+/// Check both names are valid and that the "from" name is not in a builtin
+/// namespace.
+fn validate_modify(
+    from_ns: &str,
+    from_hn: &str,
+    to_ns: &str,
+    to_hn: &str,
+) -> Result<(dns::Namespace, dns::Namespace), (StatusCode, Json<ProblemDetail>)> {
+    let from_namespace = validate_name(from_ns, from_hn)?;
+    let to_namespace = validate_name(to_ns, to_hn)?;
+
+    if is_builtin(&from_namespace) {
+        Err(ProblemDetail::modification_not_allowed(
+            "Built-in DNS namespaces cannot be modified via the API.",
+        ))
+    } else {
+        Ok((from_namespace, to_namespace))
+    }
+}
+
+/// Check that the name is valid.
+fn validate_name(
+    ns: &str,
+    hostname: &str,
+) -> Result<dns::Namespace, (StatusCode, Json<ProblemDetail>)> {
+    let namespace =
+        dns::Namespace::from_str(ns).map_err(|_| ProblemDetail::invalid_dns_namespace(ns))?;
+
+    if util::is_valid_dns_label(hostname) {
+        Ok(namespace)
+    } else {
+        Err(ProblemDetail::invalid_dns_label(hostname))
+    }
+}
+
+/// Check if the namespace is a builtin one - builtin namespaces cannot be
+/// modified via the API.
+fn is_builtin(namespace: &dns::Namespace) -> bool {
+    !matches!(namespace, dns::Namespace::Custom(_))
+}

--- a/crates/apid/src/web/errors.rs
+++ b/crates/apid/src/web/errors.rs
@@ -1,0 +1,93 @@
+use axum::extract::Json;
+use axum::http::StatusCode;
+use serde::Serialize;
+
+use nodelib::error::Error;
+
+/// An RFC7807 "problem detail" object.
+#[derive(Serialize)]
+pub struct ProblemDetail {
+    #[serde(rename = "type")]
+    rtype: String,
+    title: String,
+    detail: String,
+    status: u16,
+}
+
+impl ProblemDetail {
+    pub fn from_error(error: Error) -> (StatusCode, Json<Self>) {
+        match error {
+            Error::Resource(r) => Self::resource_invalid(&format!("{r:?}")),
+            Error::EtcdResponse(_)
+            | Error::FromUtf8(_)
+            | Error::Streaming(_)
+            | Error::TonicStatus(_)
+            | Error::TonicTransport(_) => Self::internal_server_error(&format!("{error:?}")),
+        }
+    }
+
+    /// TODO: rtype URI
+    pub fn internal_server_error(detail: &str) -> (StatusCode, Json<Self>) {
+        let status = StatusCode::INTERNAL_SERVER_ERROR;
+        let pd = Self {
+            rtype: "internal-server-error".to_string(),
+            title: "Something went badly wrong, check the logs.".to_string(),
+            detail: detail.to_string(),
+            status: status.as_u16(),
+        };
+
+        (status, Json(pd))
+    }
+
+    /// TODO: rtype URI
+    pub fn resource_already_exists(rtype: &str, rname: &str) -> (StatusCode, Json<Self>) {
+        let status = StatusCode::CONFLICT;
+        let pd = Self {
+            rtype: "resource-already-exists".to_string(),
+            title: "The given resource already exists.".to_string(),
+            detail: format!("The resource '{rname}' of type '{rtype}' already exists.  If you want to replace it, delete it first."),
+            status: status.as_u16(),
+        };
+
+        (status, Json(pd))
+    }
+
+    /// TODO: rtype URI
+    pub fn resource_invalid(detail: &str) -> (StatusCode, Json<Self>) {
+        let status = StatusCode::UNPROCESSABLE_ENTITY;
+        let pd = Self {
+            rtype: "resource-invalid".to_string(),
+            title: "The given resource is invalid.".to_string(),
+            detail: detail.to_string(),
+            status: status.as_u16(),
+        };
+
+        (status, Json(pd))
+    }
+
+    /// TODO: rtype URI
+    pub fn resource_not_found(rtype: &str, rname: &str) -> (StatusCode, Json<Self>) {
+        let status = StatusCode::NOT_FOUND;
+        let pd = Self {
+            rtype: "resource-not-found".to_string(),
+            title: "The given resource does not exist.".to_string(),
+            detail: format!("The resource '{rname}' of type '{rtype}' does not exist."),
+            status: status.as_u16(),
+        };
+
+        (status, Json(pd))
+    }
+
+    /// TODO: rtype URI
+    pub fn modification_not_allowed(detail: &str) -> (StatusCode, Json<Self>) {
+        let status = StatusCode::UNPROCESSABLE_ENTITY;
+        let pd = Self {
+            rtype: "modification-not-allowed".to_string(),
+            title: "The given change is not permitted.".to_string(),
+            detail: detail.to_string(),
+            status: status.as_u16(),
+        };
+
+        (status, Json(pd))
+    }
+}

--- a/crates/apid/src/web/errors.rs
+++ b/crates/apid/src/web/errors.rs
@@ -2,6 +2,7 @@ use axum::extract::Json;
 use axum::http::StatusCode;
 use serde::Serialize;
 
+use nodelib::dns::Namespace;
 use nodelib::error::Error;
 
 /// An RFC7807 "problem detail" object.
@@ -85,6 +86,52 @@ impl ProblemDetail {
             rtype: "modification-not-allowed".to_string(),
             title: "The given change is not permitted.".to_string(),
             detail: detail.to_string(),
+            status: status.as_u16(),
+        };
+
+        (status, Json(pd))
+    }
+
+    /// TODO: rtype URI
+    pub fn invalid_dns_namespace(ns: &str) -> (StatusCode, Json<Self>) {
+        let status = StatusCode::UNPROCESSABLE_ENTITY;
+        let pd = Self {
+            rtype: "invalid-dns-namespace".to_string(),
+            title: "The given DNS namespace is invalid".to_string(),
+            detail: format!("'{ns}' is not a valid DNS namespace: a namespace must be a valid DNS label and not clash with any builtins."),
+            status: status.as_u16(),
+        };
+
+        (status, Json(pd))
+    }
+
+    /// TODO: rtype URI
+    pub fn invalid_dns_label(lbl: &str) -> (StatusCode, Json<Self>) {
+        let status = StatusCode::UNPROCESSABLE_ENTITY;
+        let pd = Self {
+            rtype: "invalid-dns-label".to_string(),
+            title: "The given DNS label is invalid".to_string(),
+            detail: format!("'{lbl}' is not a valid DNS label: a label must be lowercase; at most 63 characters long; consist only of ASCII letters, numbers, and hyphens; start with a letter; and not end with a hyphen."),
+            status: status.as_u16(),
+        };
+
+        (status, Json(pd))
+    }
+
+    /// TODO: rtype URI
+    pub fn dns_alias_not_found(
+        from_ns: &Namespace,
+        from_hn: &str,
+        to_ns: &Namespace,
+        to_hn: &str,
+    ) -> (StatusCode, Json<Self>) {
+        let status = StatusCode::NOT_FOUND;
+        let pd = Self {
+            rtype: "dns-alias-not-found".to_string(),
+            title: "The given DNS alias does not exist.".to_string(),
+            detail: format!(
+                "The DNS alias '{from_ns}/{from_hn}' -> '{to_ns}/{to_hn}' does not exist."
+            ),
             status: status.as_u16(),
         };
 

--- a/crates/apid/src/web/mod.rs
+++ b/crates/apid/src/web/mod.rs
@@ -1,0 +1,34 @@
+pub mod errors;
+pub mod resources;
+
+use axum::routing::{delete, get, patch, post};
+use axum::Router;
+use std::net::Ipv4Addr;
+use std::process;
+
+use nodelib::etcd;
+
+/// Exit code to use if the server fails to start
+pub static EXIT_FAILURE: i32 = 1;
+
+pub async fn serve(etcd_config: etcd::Config, address: Ipv4Addr) {
+    if let Err(error) = run(etcd_config, address).await {
+        tracing::error!(?error, "could not serve application, terminating...");
+        process::exit(EXIT_FAILURE);
+    }
+}
+
+async fn run(etcd_config: etcd::Config, address: Ipv4Addr) -> std::io::Result<()> {
+    let app = Router::new()
+        .route("/resources", post(resources::create))
+        .route("/resources/:type", get(resources::list))
+        .route("/resources/:type/:name", get(resources::get))
+        .route("/resources/:type/:name", patch(resources::patch))
+        .route("/resources/:type/:name", delete(resources::delete))
+        .with_state(etcd_config);
+
+    let listener = tokio::net::TcpListener::bind((address, 80)).await?;
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}

--- a/crates/apid/src/web/mod.rs
+++ b/crates/apid/src/web/mod.rs
@@ -1,7 +1,8 @@
+pub mod dns_aliases;
 pub mod errors;
 pub mod resources;
 
-use axum::routing::{delete, get, patch, post};
+use axum::routing::{delete, get, patch, post, put};
 use axum::Router;
 use std::net::Ipv4Addr;
 use std::process;
@@ -20,6 +21,22 @@ pub async fn serve(etcd_config: etcd::Config, address: Ipv4Addr) {
 
 async fn run(etcd_config: etcd::Config, address: Ipv4Addr) -> std::io::Result<()> {
     let app = Router::new()
+        .route(
+            "/dns_aliases/:from_namespace/:from_hostname",
+            get(dns_aliases::list),
+        )
+        .route(
+            "/dns_aliases/:from_namespace/:from_hostname/:to_namespace/:to_hostname",
+            get(dns_aliases::get),
+        )
+        .route(
+            "/dns_aliases/:from_namespace/:from_hostname/:to_namespace/:to_hostname",
+            put(dns_aliases::put),
+        )
+        .route(
+            "/dns_aliases/:from_namespace/:from_hostname/:to_namespace/:to_hostname",
+            delete(dns_aliases::delete),
+        )
         .route("/resources", post(resources::create))
         .route("/resources/:type", get(resources::list))
         .route("/resources/:type/:name", get(resources::get))

--- a/crates/apid/src/web/resources.rs
+++ b/crates/apid/src/web/resources.rs
@@ -1,13 +1,8 @@
 use axum::extract::{Json, Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::routing::{delete, get, patch, post};
-use axum::Router;
-use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
-use std::net::Ipv4Addr;
-use std::process;
 use std::str::FromStr;
 
 use nodelib::error::{Error, ResourceError};
@@ -18,38 +13,13 @@ use nodelib::resources::node::*;
 use nodelib::resources::pod::*;
 use nodelib::resources::Resource;
 
-/// Exit code to use if the server fails to start
-pub static EXIT_FAILURE: i32 = 1;
-
-pub async fn serve(etcd_config: etcd::Config, address: Ipv4Addr) {
-    if let Err(error) = run(etcd_config, address).await {
-        tracing::error!(?error, "could not serve application, terminating...");
-        process::exit(EXIT_FAILURE);
-    }
-}
-
-async fn run(etcd_config: etcd::Config, address: Ipv4Addr) -> std::io::Result<()> {
-    let app = Router::new()
-        .route("/resources", post(create_resource))
-        .route("/resources/:type", get(list_resources))
-        .route("/resources/:type/:name", get(get_resource))
-        .route("/resources/:type/:name", patch(patch_resource))
-        .route("/resources/:type/:name", delete(delete_resource))
-        .with_state(etcd_config);
-
-    let listener = tokio::net::TcpListener::bind((address, 80)).await?;
-    axum::serve(listener, app).await?;
-
-    Ok(())
-}
-
-///////////////////////////////////////////////////////////////////////////////
+use crate::web::errors::ProblemDetail;
 
 // TODO: return a `ProblemDetail` if the request fails to decode - see
 // https://github.com/tokio-rs/axum/blob/main/examples/customize-extractor-error/src/custom_extractor.rs
 
 /// Create a resource.
-async fn create_resource(
+pub async fn create(
     State(etcd_config): State<etcd::Config>,
     Json(payload): Json<Resource>,
 ) -> impl IntoResponse {
@@ -78,7 +48,7 @@ async fn create_resource(
 }
 
 /// List all resources of the given type.
-async fn list_resources(
+pub async fn list(
     State(etcd_config): State<etcd::Config>,
     Path(rtype): Path<String>,
 ) -> impl IntoResponse {
@@ -92,7 +62,7 @@ async fn list_resources(
 }
 
 /// Get a specific resource.
-async fn get_resource(
+pub async fn get(
     State(etcd_config): State<etcd::Config>,
     Path((rtype, rname)): Path<(String, String)>,
 ) -> impl IntoResponse {
@@ -107,7 +77,7 @@ async fn get_resource(
 }
 
 /// Modify a resource in place - the `type` and `name` cannot be modified.
-async fn patch_resource(
+pub async fn patch(
     State(etcd_config): State<etcd::Config>,
     Path((rtype, rname)): Path<(String, String)>,
     Json(payload): Json<Value>,
@@ -143,7 +113,7 @@ async fn patch_resource(
 }
 
 /// Delete a specific resource.
-async fn delete_resource(
+pub async fn delete(
     State(etcd_config): State<etcd::Config>,
     Path((rtype, rname)): Path<(String, String)>,
 ) -> impl IntoResponse {
@@ -162,96 +132,6 @@ async fn delete_resource(
             Ok(false) => ProblemDetail::resource_not_found(&rtype, &rname).into_response(),
             Err(error) => ProblemDetail::from_error(error).into_response(),
         }
-    }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-/// An RFC7807 "problem detail" object.
-#[derive(Serialize)]
-struct ProblemDetail {
-    #[serde(rename = "type")]
-    rtype: String,
-    title: String,
-    detail: String,
-    status: u16,
-}
-
-impl ProblemDetail {
-    fn from_error(error: Error) -> (StatusCode, Json<Self>) {
-        match error {
-            Error::Resource(r) => Self::resource_invalid(&format!("{r:?}")),
-            Error::EtcdResponse(_)
-            | Error::FromUtf8(_)
-            | Error::Streaming(_)
-            | Error::TonicStatus(_)
-            | Error::TonicTransport(_) => Self::internal_server_error(&format!("{error:?}")),
-        }
-    }
-
-    /// TODO: rtype URI
-    fn internal_server_error(detail: &str) -> (StatusCode, Json<Self>) {
-        let status = StatusCode::INTERNAL_SERVER_ERROR;
-        let pd = Self {
-            rtype: "internal-server-error".to_string(),
-            title: "Something went badly wrong, check the logs.".to_string(),
-            detail: detail.to_string(),
-            status: status.as_u16(),
-        };
-
-        (status, Json(pd))
-    }
-
-    /// TODO: rtype URI
-    fn resource_already_exists(rtype: &str, rname: &str) -> (StatusCode, Json<Self>) {
-        let status = StatusCode::CONFLICT;
-        let pd = Self {
-            rtype: "resource-already-exists".to_string(),
-            title: "The given resource already exists.".to_string(),
-            detail: format!("The resource '{rname}' of type '{rtype}' already exists.  If you want to replace it, delete it first."),
-            status: status.as_u16(),
-        };
-
-        (status, Json(pd))
-    }
-
-    /// TODO: rtype URI
-    fn resource_invalid(detail: &str) -> (StatusCode, Json<Self>) {
-        let status = StatusCode::UNPROCESSABLE_ENTITY;
-        let pd = Self {
-            rtype: "resource-invalid".to_string(),
-            title: "The given resource is invalid.".to_string(),
-            detail: detail.to_string(),
-            status: status.as_u16(),
-        };
-
-        (status, Json(pd))
-    }
-
-    /// TODO: rtype URI
-    fn resource_not_found(rtype: &str, rname: &str) -> (StatusCode, Json<Self>) {
-        let status = StatusCode::NOT_FOUND;
-        let pd = Self {
-            rtype: "resource-not-found".to_string(),
-            title: "The given resource does not exist.".to_string(),
-            detail: format!("The resource '{rname}' of type '{rtype}' does not exist."),
-            status: status.as_u16(),
-        };
-
-        (status, Json(pd))
-    }
-
-    /// TODO: rtype URI
-    fn modification_not_allowed(detail: &str) -> (StatusCode, Json<Self>) {
-        let status = StatusCode::UNPROCESSABLE_ENTITY;
-        let pd = Self {
-            rtype: "modification-not-allowed".to_string(),
-            title: "The given change is not permitted.".to_string(),
-            detail: detail.to_string(),
-            status: status.as_u16(),
-        };
-
-        (status, Json(pd))
     }
 }
 

--- a/crates/nodelib/src/etcd/mod.rs
+++ b/crates/nodelib/src/etcd/mod.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod leaser;
 pub mod pb;
 pub mod prefix;
+pub mod util;
 pub mod watcher;
 
 // convenience re-export

--- a/crates/nodelib/src/etcd/util.rs
+++ b/crates/nodelib/src/etcd/util.rs
@@ -3,8 +3,56 @@ use tonic::Request;
 use crate::error::Error;
 use crate::etcd;
 use crate::etcd::pb::etcdserverpb::compare;
+use crate::etcd::pb::etcdserverpb::range_request::{SortOrder, SortTarget};
 use crate::etcd::pb::etcdserverpb::request_op;
-use crate::etcd::pb::etcdserverpb::{Compare, DeleteRangeRequest, RequestOp, TxnRequest};
+use crate::etcd::pb::etcdserverpb::{
+    Compare, DeleteRangeRequest, RangeRequest, RequestOp, TxnRequest,
+};
+use crate::etcd::pb::mvccpb::KeyValue;
+use crate::etcd::prefix;
+
+/// List all key-value pairs under the given prefix.  Everything is fetched at
+/// the given revision (or the latest revision, if 0 is given), which is returned.
+pub async fn list_kvs(
+    config: &etcd::Config,
+    key_prefix: String,
+    mut revision: i64,
+) -> Result<(Vec<KeyValue>, i64), Error> {
+    let mut out = Vec::new();
+
+    let mut kv_client = config.kv_client().await?;
+
+    let range_end = prefix::range_end(&key_prefix);
+    let mut key = key_prefix.as_bytes().to_vec();
+
+    loop {
+        let response = kv_client
+            .range(Request::new(RangeRequest {
+                key,
+                range_end: range_end.clone(),
+                revision,
+                sort_order: SortOrder::Ascend.into(),
+                sort_target: SortTarget::Key.into(),
+                ..Default::default()
+            }))
+            .await?
+            .into_inner();
+        revision = response.header.unwrap().revision;
+
+        for kv in &response.kvs {
+            out.push(kv.clone());
+        }
+
+        if response.more {
+            let idx = response.kvs.len() - 1;
+            key = response.kvs[idx].key.clone();
+        } else {
+            break;
+        }
+    }
+
+    Ok((out, revision))
+}
 
 /// Delete a key.  Returns `false` if the key does not exist.
 pub async fn delete_if_exists(config: &etcd::Config, key: String) -> Result<bool, Error> {

--- a/crates/nodelib/src/etcd/util.rs
+++ b/crates/nodelib/src/etcd/util.rs
@@ -1,0 +1,34 @@
+use tonic::Request;
+
+use crate::error::Error;
+use crate::etcd;
+use crate::etcd::pb::etcdserverpb::compare;
+use crate::etcd::pb::etcdserverpb::request_op;
+use crate::etcd::pb::etcdserverpb::{Compare, DeleteRangeRequest, RequestOp, TxnRequest};
+
+/// Delete a key.  Returns `false` if the key does not exist.
+pub async fn delete_if_exists(config: &etcd::Config, key: String) -> Result<bool, Error> {
+    let mut kv_client = config.kv_client().await?;
+    let res = kv_client
+        .txn(Request::new(TxnRequest {
+            // create revision (ie `Create`) != 0 => the key exists
+            compare: vec![Compare {
+                result: compare::CompareResult::NotEqual.into(),
+                target: compare::CompareTarget::Create.into(),
+                key: key.clone().into(),
+                ..Default::default()
+            }],
+            success: vec![RequestOp {
+                request: Some(request_op::Request::RequestDeleteRange(
+                    DeleteRangeRequest {
+                        key: key.into(),
+                        ..Default::default()
+                    },
+                )),
+            }],
+            failure: Vec::new(),
+        }))
+        .await?;
+
+    Ok(res.into_inner().succeeded)
+}

--- a/crates/nodelib/src/lib.rs
+++ b/crates/nodelib/src/lib.rs
@@ -83,7 +83,7 @@ pub async fn initialise(
         dns::create_leased_a_record(
             &etcd_config,
             alive_lease_id,
-            dns::Namespace::Node(node_type),
+            &dns::Namespace::Node(node_type),
             &name,
             ip,
         )
@@ -93,9 +93,9 @@ pub async fn initialise(
             dns::append_alias_record(
                 &etcd_config,
                 Some(alive_lease_id),
-                dns::Namespace::Special,
+                &dns::Namespace::Special,
                 alias,
-                dns::Namespace::Node(node_type),
+                &dns::Namespace::Node(node_type),
                 &name,
             )
             .await?;

--- a/crates/nodelib/src/resources/mod.rs
+++ b/crates/nodelib/src/resources/mod.rs
@@ -9,7 +9,6 @@ use tonic::Request;
 use crate::error::{Error, ResourceError};
 use crate::etcd;
 use crate::etcd::pb::etcdserverpb::compare;
-use crate::etcd::pb::etcdserverpb::range_request::{SortOrder, SortTarget};
 use crate::etcd::pb::etcdserverpb::request_op;
 use crate::etcd::pb::etcdserverpb::{
     Compare, DeleteRangeRequest, PutRequest, RangeRequest, RequestOp, TxnRequest,
@@ -51,40 +50,13 @@ pub async fn get(
 
 /// List all resources of the given type.
 pub async fn list(etcd_config: &etcd::Config, rtype: &str) -> Result<Vec<Resource>, Error> {
-    let mut out = Vec::new();
+    let (kvs, _) =
+        etcd::util::list_kvs(etcd_config, prefix::resource(etcd_config, rtype), 0).await?;
 
-    let mut kv_client = etcd_config.kv_client().await?;
-    let mut revision = 0;
-
-    let key_prefix = prefix::resource(etcd_config, rtype);
-    let range_end = prefix::range_end(&key_prefix);
-    let mut key = key_prefix.as_bytes().to_vec();
-
-    loop {
-        let response = kv_client
-            .range(Request::new(RangeRequest {
-                key,
-                range_end: range_end.clone(),
-                revision,
-                sort_order: SortOrder::Ascend.into(),
-                sort_target: SortTarget::Key.into(),
-                ..Default::default()
-            }))
-            .await?
-            .into_inner();
-        revision = response.header.unwrap().revision;
-
-        for kv in &response.kvs {
-            let resource = Resource::try_from(kv.clone().value)?;
-            out.push(resource);
-        }
-
-        if response.more {
-            let idx = response.kvs.len() - 1;
-            key = response.kvs[idx].key.clone();
-        } else {
-            break;
-        }
+    let mut out = Vec::with_capacity(kvs.len());
+    for kv in kvs {
+        let resource = Resource::try_from(kv.value)?;
+        out.push(resource);
     }
 
     Ok(out)

--- a/crates/nodelib/src/resources/types.rs
+++ b/crates/nodelib/src/resources/types.rs
@@ -6,6 +6,7 @@ use crate::error::ResourceError;
 use crate::etcd;
 use crate::etcd::pb::etcdserverpb::PutRequest;
 use crate::etcd::prefix;
+use crate::util;
 
 /// A resource where the type and state are strings and the spec is a JSON
 /// object.
@@ -120,15 +121,9 @@ impl TryFrom<Vec<u8>> for Resource {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-/// Check that a name is all lowercase and is a valid DNS label.
+/// Resource names must be valid DNS labels.
 fn is_valid_resource_name(name: &str) -> bool {
-    let valid_character = |c: char| c.is_ascii_alphanumeric() || c == '-';
-
-    !name.is_empty()
-        && name.len() <= 63
-        && name.chars().all(valid_character)
-        && name.starts_with(|c: char| c.is_ascii_alphabetic())
-        && !name.ends_with(|c: char| c == '-')
+    util::is_valid_dns_label(name)
 }
 
 /// Check that a type name is nonempty and of the form

--- a/crates/nodelib/src/util.rs
+++ b/crates/nodelib/src/util.rs
@@ -89,3 +89,14 @@ pub fn random_name() -> String {
         d4 = DIGITS.choose(&mut rng).unwrap(),
     )
 }
+
+/// Check that a string is all lowercase and is a valid DNS label.
+pub fn is_valid_dns_label(s: &str) -> bool {
+    let valid_character = |c: char| c.is_ascii_alphanumeric() || c == '-';
+
+    !s.is_empty()
+        && s.len() <= 63
+        && s.chars().all(valid_character)
+        && s.starts_with(|c: char| c.is_ascii_alphabetic())
+        && !s.ends_with(|c: char| c == '-')
+}

--- a/crates/workerd/src/pod_worker.rs
+++ b/crates/workerd/src/pod_worker.rs
@@ -272,7 +272,7 @@ async fn create_pod_dns_record(
     while let Err(error) = dns::create_leased_a_record(
         etcd_config,
         lease_id,
-        dns::Namespace::Pod,
+        &dns::Namespace::Pod,
         &pod_state.hostname,
         pod_state.address,
     )
@@ -288,7 +288,7 @@ async fn create_pod_dns_record(
 /// TODO: add a retry limit
 async fn delete_pod_dns_record(etcd_config: &etcd::Config, pod_state: &podman::PodState) {
     while let Err(error) =
-        dns::delete_record(etcd_config, dns::Namespace::Pod, &pod_state.hostname).await
+        dns::delete_record(etcd_config, &dns::Namespace::Pod, &pod_state.hostname).await
     {
         tracing::warn!(?error, "could not destroy DNS record, retrying...");
         tokio::time::sleep(Duration::from_secs(1)).await;

--- a/integration-tests/test-vm-works.nix
+++ b/integration-tests/test-vm-works.nix
@@ -25,5 +25,8 @@ defaults: {
 
     for ty in NODE_TYPES:
         machine.succeed(f"curl --fail-with-body http://127.0.0.1/resources/node.{ty}/{NODE_NAME}")
+
+    machine.succeed("curl --fail-with-body http://127.0.0.1/dns_aliases/special/api/api.node/machine")
+    machine.succeed("curl --fail-with-body http://127.0.0.1/dns_aliases/special/dns/worker.node/machine")
   '';
 }


### PR DESCRIPTION
To build group-of-pod abstractions like services, I'll need the ability
to create custom DNS aliases that refer to multiple pods, or possibly
even a mixture of pods and other aliases.