### PR TITLE
Fix race condition in scan / watch setup

### DIFF
--- a/crates/nodelib/src/dns.rs
+++ b/crates/nodelib/src/dns.rs
@@ -108,7 +108,7 @@ pub async fn list_aliases(
         "{prefix}/",
         prefix = record_key(etcd_config, from_namespace, from_hostname),
     );
-    let (kvs, _) = etcd::util::list_kvs(etcd_config, key_prefix.clone(), 0).await?;
+    let (kvs, _) = etcd::util::list_kvs(etcd_config, key_prefix.clone(), None).await?;
 
     let mut out = Vec::with_capacity(kvs.len());
     for kv in kvs {

--- a/crates/nodelib/src/resources/mod.rs
+++ b/crates/nodelib/src/resources/mod.rs
@@ -51,7 +51,7 @@ pub async fn get(
 /// List all resources of the given type.
 pub async fn list(etcd_config: &etcd::Config, rtype: &str) -> Result<Vec<Resource>, Error> {
     let (kvs, _) =
-        etcd::util::list_kvs(etcd_config, prefix::resource(etcd_config, rtype), 0).await?;
+        etcd::util::list_kvs(etcd_config, prefix::resource(etcd_config, rtype), None).await?;
 
     let mut out = Vec::with_capacity(kvs.len());
     for kv in kvs {

--- a/crates/reaperd/src/node_reaper.rs
+++ b/crates/reaperd/src/node_reaper.rs
@@ -130,7 +130,7 @@ async fn get_inbox_for_node(
     node_name: &NodeName,
 ) -> Result<Vec<PodName>, Error> {
     let key_prefix = prefix::worker_inbox(etcd_config, &node_name.0);
-    let (kvs, _) = etcd::util::list_kvs(etcd_config, key_prefix.clone(), 0).await?;
+    let (kvs, _) = etcd::util::list_kvs(etcd_config, key_prefix.clone(), None).await?;
 
     let mut to_reap = Vec::with_capacity(kvs.len());
     for kv in kvs {

--- a/integration-tests/test-container-networking.nix
+++ b/integration-tests/test-container-networking.nix
@@ -132,12 +132,11 @@ in
     # start apid and schedulerd on `infra`, workerd on `node1` and `node2`
     infra.systemctl("start thing-doer-apid")
     infra.systemctl("start thing-doer-schedulerd")
-    infra.wait_for_unit("thing-doer-apid")
-    infra.wait_for_unit("thing-doer-schedulerd")
-
-    # TODO: there is a race condition where concurrent workerd / schedulerd startup can lead to schedulerd missing state
     node1.systemctl("start thing-doer-workerd")
     node2.systemctl("start thing-doer-workerd")
+
+    infra.wait_for_unit("thing-doer-apid")
+    infra.wait_for_unit("thing-doer-schedulerd")
     node1.wait_for_unit("thing-doer-workerd")
     node2.wait_for_unit("thing-doer-workerd")
 


### PR DESCRIPTION
I set up a watch by:

1. Scanning all the keys under all of the prefix
2. Establishing a watch from the revision returned by the scan

To avoid missing data, it's essential that all the scanning is done at the *same* revision.  Otherwise, if the scan requires multiple requests, and some data is written between the two requests, the second request could miss it.

Unfortunately, that's what seemed to be happening.

I was able to track it down by adding a bit more logging of revision numbers: each scan used the following revision, rather than using the same revision!  Turns out that I had misinterpreted the meaning of the `revision` field of the response header.  The documentation says:

> revision is the key-value store revision when the request was applied.

Which is terse, but made me think that:

- If I don't supply a revision in the `RangeRequest` (ie, `revision: 0`) it returns the latest revision.
- If I do supply a revision in the `RangeRequest`, it uses that.

That's not right.  The header `revision` is actually the latest revision at the time the request was answered, and has no relation to the revision specified in the request.

So the correct thing to do is, on the very first request, to not supply a revision - and then use the header `revision` returned *from that first request* for all subsequent requests.

Closes #32 